### PR TITLE
Add options to serve command

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "php": ">=5.4.0",
         "illuminate/support": "4.2.*",
-        "voryx/thruway":"0.3.*"
+        "voryx/thruway":"0.2.*"
     },
     "autoload": {
         "psr-0": {

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "php": ">=5.4.0",
         "illuminate/support": "4.2.*",
-        "voryx/thruway":"0.2.*"
+        "voryx/thruway":"0.3.*"
     },
     "autoload": {
         "psr-0": {

--- a/src/LaravelFanatic/Socketer/Commands/ServeSocketerCommand.php
+++ b/src/LaravelFanatic/Socketer/Commands/ServeSocketerCommand.php
@@ -43,6 +43,9 @@ class ServeSocketerCommand extends Command{
     */
     public function fire()
     {
+        $port = $this->option('port');
+        $address = $this->option('ip_address');
+        
         $socketer = \App::make('LaravelFanatic\Socketer\Socketer');
 
         $loop = \React\EventLoop\Factory::create();
@@ -51,7 +54,7 @@ class ServeSocketerCommand extends Command{
 
         $router = new Router($loop);
 
-        $transportProvider = new RatchetTransportProvider("127.0.0.1", 9090);
+        $transportProvider = new RatchetTransportProvider($address, $port);
 
         $internalClientTransportProvider = new \Thruway\Transport\InternalClientTransportProvider($socketer);
 
@@ -59,6 +62,14 @@ class ServeSocketerCommand extends Command{
         $router->addTransportProvider($internalClientTransportProvider);
 
         $router->start();
+    }
+    
+    public function getOptions()
+    {
+        return [
+	       ['ip_address', 'i', InputOption::VALUE_OPTIONAL, 'IP Address', '127.0.0.1'],
+	       ['port', 'p', InputOption::VALUE_OPTIONAL, 'TCP Port', '9090'],
+        ];
     }
 
 }

--- a/src/LaravelFanatic/Socketer/Commands/ServeSocketerCommand.php
+++ b/src/LaravelFanatic/Socketer/Commands/ServeSocketerCommand.php
@@ -45,8 +45,9 @@ class ServeSocketerCommand extends Command{
     {
         $port = $this->option('port');
         $address = $this->option('ip_address');
+        $realm = $this->option('realm');
         
-        $socketer = \App::make('LaravelFanatic\Socketer\Socketer');
+        $socketer = \App::make('LaravelFanatic\Socketer\Socketer', [$realm]);
 
         $loop = \React\EventLoop\Factory::create();
 
@@ -69,6 +70,7 @@ class ServeSocketerCommand extends Command{
         return [
 	       ['ip_address', 'i', InputOption::VALUE_OPTIONAL, 'IP Address', '127.0.0.1'],
 	       ['port', 'p', InputOption::VALUE_OPTIONAL, 'TCP Port', '9090'],
+	       ['realm', 'r', InputOption::VALUE_OPTIONAL, 'WAMP Realm', 'realm1'],
         ];
     }
 

--- a/src/LaravelFanatic/Socketer/Socketer.php
+++ b/src/LaravelFanatic/Socketer/Socketer.php
@@ -10,9 +10,9 @@ class Socketer extends Client{
     /**
     * Contructor
     */
-    public function __construct()
+    public function __construct($realm)
     {
-        parent::__construct("realm1");
+        parent::__construct($realm);
     }
 
     public function start(){


### PR DESCRIPTION
I've updated the command to allow options for setting the IP address, TCP port and WAMP realm. This allows for bindings such as this:

php artisan socketer:serve --ip_address="0.0.0.0" --port="8080" --realm="some.other.realm"